### PR TITLE
feat: implement proper Typesense binary download and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # asdf-typesense [![Build](https://github.com/MiroslavCsonka/asdf-typesense/actions/workflows/build.yml/badge.svg)](https://github.com/MiroslavCsonka/asdf-typesense/actions/workflows/build.yml) [![Lint](https://github.com/MiroslavCsonka/asdf-typesense/actions/workflows/lint.yml/badge.svg)](https://github.com/MiroslavCsonka/asdf-typesense/actions/workflows/lint.yml)
 
-[typesense](https://typesense.org) plugin for the [asdf version manager](https://asdf-vm.com).
+[Typesense](https://typesense.org) plugin for the [Mise version manager](https://mise.jdx.dev) (compatible with asdf).
 
 </div>
 
@@ -15,39 +15,42 @@
 
 # Dependencies
 
-**TODO: adapt this section**
-
+- macOS Ventura (13.x) or newer (Typesense binary requirement).
 - `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
-- `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
+- Mise (or asdf) installed.
 
 # Install
 
 Plugin:
 
 ```shell
-asdf plugin add typesense
+mise plugins install typesense
 # or
-asdf plugin add typesense https://github.com/MiroslavCsonka/asdf-typesense.git
+mise plugins install typesense https://github.com/MiroslavCsonka/asdf-typesense.git
 ```
 
-typesense:
+Typesense:
 
 ```shell
 # Show all installable versions
-asdf list-all typesense
+mise ls-remote typesense
 
 # Install specific version
-asdf install typesense latest
+mise install typesense 0.25.2
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global typesense latest
+mise global typesense 0.25.2
 
-# Now typesense commands are available
+# Now typesense-server commands are available
 typesense-server --version
 ```
 
-Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
-install & manage versions.
+Check [Mise](https://mise.jdx.dev) readme for more instructions on how to install & manage versions. Supports amd64 (Intel) and arm64 (Apple Silicon). For CI (e.g., GitHub Actions), use in macOS runners.
+
+## Notes
+- Versions are fetched from Typesense GitHub releases.
+- Requires no additional dependencies beyond curl (available on macOS).
+- For older macOS, use Docker instead (per Typesense docs).
 
 # Contributing
 

--- a/bin/download
+++ b/bin/download
@@ -5,19 +5,32 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=./lib/utils.bash
+# shellcheck source=lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-# TODO: Adapt this to proper extension and adapt extracting strategy.
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+# Environment variables provided by Mise/asdf
+VERSION="${ASDF_INSTALL_VERSION}"
+DOWNLOAD_DIR="${ASDF_DOWNLOAD_PATH}"
 
-# Download tar.gz file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+# Detect architecture (Darwin/macOS only)
+ARCH="$(uname -m)"
+case "${ARCH}" in
+arm64) ARCH="arm64" ;;
+x86_64) ARCH="amd64" ;;
+*) fail "Unsupported architecture: ${ARCH}" ;;
+esac
 
-#  Extract contents of tar.gz file into the download directory
-tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+# Construct download URL
+URL="https://dl.typesense.org/releases/${VERSION}/typesense-server-${VERSION}-darwin-${ARCH}.tar.gz"
 
-# Remove the tar.gz file since we don't need to keep it
-rm "$release_file"
+# Download the tar.gz
+echo "* Downloading $TOOL_NAME release $VERSION..."
+curl "${curl_opts[@]}" -o "${DOWNLOAD_DIR}/typesense.tar.gz" "$URL" || fail "Could not download $URL"
+
+# Extract the tar.gz to download directory
+tar -xzf "${DOWNLOAD_DIR}/typesense.tar.gz" -C "${DOWNLOAD_DIR}"
+
+# Cleanup tar.gz
+rm -f "${DOWNLOAD_DIR}/typesense.tar.gz"

--- a/bin/install
+++ b/bin/install
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=./lib/utils.bash
+# shellcheck source=lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "bin"

--- a/contributing.md
+++ b/contributing.md
@@ -5,8 +5,5 @@ Testing Locally:
 ```shell
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
-# TODO: adapt this
 asdf plugin test typesense https://github.com/MiroslavCsonka/asdf-typesense.git "typesense-server --version"
 ```
-
-Tests are automatically run in GitHub Actions on push and PR.

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-# TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for typesense.
 GH_REPO="https://github.com/typesense/typesense"
 TOOL_NAME="typesense"
 TOOL_TEST="typesense-server --version"
@@ -27,12 +26,10 @@ sort_versions() {
 list_github_tags() {
 	git ls-remote --tags --refs "$GH_REPO" |
 		grep -o 'refs/tags/.*' | cut -d/ -f3- |
-		sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+		sed 's/^v//'
 }
 
 list_all_versions() {
-	# TODO: Adapt this. By default we simply list the tag names from GitHub releases.
-	# Change this function if typesense has other means of determining installable versions.
 	list_github_tags
 }
 
@@ -41,7 +38,8 @@ download_release() {
 	version="$1"
 	filename="$2"
 
-	# TODO: Adapt the release URL convention for typesense
+	# This function is not used since we have a custom bin/download script
+	# that downloads the pre-built binaries directly from dl.typesense.org
 	url="$GH_REPO/archive/v${version}.tar.gz"
 
 	echo "* Downloading $TOOL_NAME release $version..."
@@ -59,9 +57,15 @@ install_version() {
 
 	(
 		mkdir -p "$install_path"
-		cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
 
-		# TODO: Assert typesense executable exists.
+		# Move the typesense-server binary to the install path
+		if [ -f "$ASDF_DOWNLOAD_PATH/typesense-server" ]; then
+			mv "$ASDF_DOWNLOAD_PATH/typesense-server" "$install_path/"
+			chmod +x "$install_path/typesense-server"
+		else
+			fail "typesense-server binary not found in download directory"
+		fi
+
 		local tool_cmd
 		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
 		test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."


### PR DESCRIPTION
## Summary
- Implemented proper download mechanism for Typesense macOS binaries from dl.typesense.org
- Added support for both Intel (amd64) and Apple Silicon (arm64) architectures
- Updated documentation to focus on Mise usage while maintaining asdf compatibility

## Changes
- Created custom `bin/download` script to fetch pre-built binaries instead of source archives
- Modified `bin/install` to work with the new download mechanism
- Added `bin/list-bin-paths` for proper asdf/mise integration
- Updated README with Mise-focused documentation and macOS requirements
- Removed template TODOs and adapted all functionality for Typesense

## Test plan
- [x] Tested `bin/list-all` - lists all available versions
- [x] Tested `bin/latest-stable` - returns latest version
- [x] Tested `bin/list-bin-paths` - returns "bin"
- [x] Tested `bin/install` manually - successfully installs Typesense 27.1
- [x] Tested with mise - plugin installs and lists versions correctly
- [x] Verified binary works with `typesense-server --version`
- [x] All scripts pass shellcheck and shfmt linting

## Note
This PR updates the plugin from the template to properly support Typesense binary downloads from the official distribution site.

🤖 Generated with [Claude Code](https://claude.ai/code)