### PR TITLE
feat: add Linux support for Typesense plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,29 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v4
-        with:
-          command: typesense-server --version
-          version: 27.1
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@v3
+        
+      - name: Add plugin locally
+        run: |
+          asdf plugin add typesense .
+          
+      - name: List all versions
+        run: |
+          asdf list all typesense
+          
+      - name: Install typesense
+        run: |
+          asdf install typesense 27.1
+          
+      - name: Set typesense version
+        run: |
+          asdf global typesense 27.1
+          
+      - name: Test typesense
+        run: |
+          export PATH="$HOME/.asdf/shims:$PATH"
+          typesense-server --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v4
         with:
           command: typesense-server --version
+          version: 27.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,5 @@ jobs:
       - name: Test typesense
         run: |
           export PATH="$HOME/.asdf/shims:$PATH"
-          typesense-server --version
+          # typesense-server --version exits with 1 but shows version
+          typesense-server --version 2>&1 | grep -q "Typesense 27.1" && echo "✓ Typesense 27.1 installed successfully"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@
 
 # Dependencies
 
-- macOS Ventura (13.x) or newer (Typesense binary requirement).
-- `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
-- Mise (or asdf) installed.
+- macOS Ventura (13.x) or newer for macOS users
+- Linux (Ubuntu, Debian, CentOS, etc.) with glibc 2.17 or newer
+- `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html)
+- Mise (or asdf) installed
 
 # Install
 
@@ -45,12 +46,16 @@ mise global typesense 0.25.2
 typesense-server --version
 ```
 
-Check [Mise](https://mise.jdx.dev) readme for more instructions on how to install & manage versions. Supports amd64 (Intel) and arm64 (Apple Silicon). For CI (e.g., GitHub Actions), use in macOS runners.
+Check [Mise](https://mise.jdx.dev) readme for more instructions on how to install & manage versions.
+
+## Supported Platforms
+- **macOS**: Intel (amd64) and Apple Silicon (arm64) - requires macOS Ventura (13.x) or newer
+- **Linux**: amd64 and arm64 architectures - requires glibc 2.17 or newer
 
 ## Notes
-- Versions are fetched from Typesense GitHub releases.
-- Requires no additional dependencies beyond curl (available on macOS).
-- For older macOS, use Docker instead (per Typesense docs).
+- Versions are fetched from Typesense GitHub releases
+- Pre-built binaries are downloaded from dl.typesense.org
+- For unsupported platforms or older OS versions, use Docker instead
 
 # Contributing
 

--- a/bin/download
+++ b/bin/download
@@ -14,16 +14,24 @@ mkdir -p "$ASDF_DOWNLOAD_PATH"
 VERSION="${ASDF_INSTALL_VERSION}"
 DOWNLOAD_DIR="${ASDF_DOWNLOAD_PATH}"
 
-# Detect architecture (Darwin/macOS only)
+# Detect OS
+OS="$(uname -s)"
+case "${OS}" in
+Darwin) OS="darwin" ;;
+Linux) OS="linux" ;;
+*) fail "Unsupported OS: ${OS}. Only macOS and Linux are supported." ;;
+esac
+
+# Detect architecture
 ARCH="$(uname -m)"
 case "${ARCH}" in
-arm64) ARCH="arm64" ;;
+arm64 | aarch64) ARCH="arm64" ;;
 x86_64) ARCH="amd64" ;;
 *) fail "Unsupported architecture: ${ARCH}" ;;
 esac
 
 # Construct download URL
-URL="https://dl.typesense.org/releases/${VERSION}/typesense-server-${VERSION}-darwin-${ARCH}.tar.gz"
+URL="https://dl.typesense.org/releases/${VERSION}/typesense-server-${VERSION}-${OS}-${ARCH}.tar.gz"
 
 # Download the tar.gz
 echo "* Downloading $TOOL_NAME release $VERSION..."


### PR DESCRIPTION
## Summary
Extends the plugin to support Linux in addition to macOS, enabling cross-platform usage.

## Changes
- Add OS detection for Linux and macOS in the download script
- Support both amd64 and arm64 architectures on Linux (aarch64 mapped to arm64)
- Update documentation to reflect cross-platform support
- Restore Ubuntu to CI test matrix for cross-platform testing

## Supported Platforms
- **macOS**: Intel (amd64) and Apple Silicon (arm64) - requires macOS Ventura (13.x) or newer
- **Linux**: amd64 and arm64 architectures - requires glibc 2.17 or newer

## Test plan
- [x] Tested download script logic for OS and architecture detection
- [x] Updated CI to test on both Ubuntu and macOS
- [x] CI tests will validate functionality on both platforms

🤖 Generated with [Claude Code](https://claude.ai/code)